### PR TITLE
fixing issue with the new materialize-sass version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,7 @@ gem 'friendly_id', '~> 5.1.0'
 # jQuery
 gem 'jquery-rails', '~> 4.3', '>= 4.3.1'
 # Materialize 
-gem 'materialize-sass'
+gem 'materialize-sass', '~> 0.100.2'
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '~> 5.1.1'
 # Use sqlite3 as the database for Active Record


### PR DESCRIPTION
The project has an error with application.html.erb file because of materialize-sass new version that's downloaded automatically without setting the version in gemfile